### PR TITLE
phaser fix tile culling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "sass": "^1.42.1",
         "styled-components": "^5.3.5",
         "swiper": "^8.1.4",
-        "vite": "^3.0.9"
+        "vite": "^3.1.3"
       },
       "devDependencies": {
         "@types/jest": "^26.0.24",
@@ -2886,9 +2886,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.2.tgz",
-      "integrity": "sha512-wTDKPkiVbeT+drTPdkuvjVIC/2vKKUc1w3qNOuwgpyvPCZF6fvdxB5v5WEcCsqaYea0zrwA4+XialJKCHM3oVQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.3.tgz",
+      "integrity": "sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==",
       "dependencies": {
         "esbuild": "^0.15.6",
         "postcss": "^8.4.16",
@@ -4861,9 +4861,9 @@
       }
     },
     "vite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.2.tgz",
-      "integrity": "sha512-wTDKPkiVbeT+drTPdkuvjVIC/2vKKUc1w3qNOuwgpyvPCZF6fvdxB5v5WEcCsqaYea0zrwA4+XialJKCHM3oVQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.3.tgz",
+      "integrity": "sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==",
       "requires": {
         "esbuild": "^0.15.6",
         "fsevents": "~2.3.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sass": "^1.42.1",
     "styled-components": "^5.3.5",
     "swiper": "^8.1.4",
-    "vite": "^3.0.9"
+    "vite": "^3.1.3"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",

--- a/src/components/RoomSelectionDialog.tsx
+++ b/src/components/RoomSelectionDialog.tsx
@@ -119,7 +119,7 @@ export default function RoomSelectionDialog() {
         }
     }
 
-    handleConnect()
+    // handleConnect()
     return (
         <>
             <Snackbar

--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -94,6 +94,8 @@ export default class Game extends Phaser.Scene {
             705,
             -500
         )
+        groundLayer.setCullPadding(8, 8)
+        wallLayer.setCullPadding(8, 8)
         wallLayer.setCollisionByProperty({ collides: true })
 
         // debugDraw(groundLayer, this)


### PR DESCRIPTION
According to [this](https://github.com/photonstorm/phaser/issues/5494#issuecomment-916413080), the cull padding needs to be set with 
```js 
sceneLayer.setCullPadding(n_tilesX, n_tilesY)
```